### PR TITLE
Updated bower.json and migrated component usages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
     "/demo"
   ],
   "dependencies": {
-    "cedar-card": "FamilySearchElements/cedar-card#1.x",
+    "fs-card": "fs-webdev/fs-card#1.x",
     "layout": "fs-webdev/layout#1.0.0",
     "polymer": "Polymer/polymer#^1.2.0",
     "wc-i18n": "jshcrowthe/wc-i18n#^2.1.0",

--- a/fs-artifact-grid-item.css
+++ b/fs-artifact-grid-item.css
@@ -123,10 +123,10 @@
   top: calc(50% - 11px);
 }
 
-cedar-card {
+fs-card {
   width: var(--grid-item-card-width);
   max-width: 170px;
-  --cedar-card-body: {
+  --fs-card-body: {
     padding: 0;
     width: 100%;
     @apply(--grid-item-card-styles);

--- a/fs-artifact-grid-item.html
+++ b/fs-artifact-grid-item.html
@@ -1,5 +1,5 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../cedar-card/cedar-card.html">
+<link rel="import" href="../fs-card/fs-card.html">
 <link rel="import" href="../wc-i18n/wc-i18n.html">
 <link rel="import" href="../oak-i18n-behavior/oak-i18n-behavior.html">
 <link rel="import" href="audio-artifact/audio-artifact.html">
@@ -21,7 +21,7 @@
       method="POST"
       on-response="_handlePostTitleResponse"
       on-error="_handlePostTitleError"></iron-ajax>
-    <cedar-card>
+    <fs-card>
       <div body>
         <div class="relative">
           <div id='artifact' class="artifact">
@@ -129,7 +129,7 @@
 
         </div>
       </div>
-    </cedar-card>
+    </fs-card>
   </template>
 </dom-module>
 <script>
@@ -139,7 +139,7 @@
     behaviors: [
       OakAJAXBehavior,
       WCI18n(),
-      OakI18nBehavior,
+      OakI18nBehavior
     ],
     properties: {
       /**


### PR DESCRIPTION
These updates are for components migrated from `FamilySearchElements` and renamed to begin with `fs`.