### PR TITLE
Upgrade to fs-styles 3.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
     "/demo"
   ],
   "dependencies": {
-    "fs-card": "fs-webdev/fs-card#2.x",
     "layout": "fs-webdev/layout#1.0.0",
     "polymer": "Polymer/polymer#^1.2.0",
     "wc-i18n": "jshcrowthe/wc-i18n#^2.1.0",
@@ -30,13 +29,14 @@
     "iron-ajax": "PolymerElements/iron-ajax#~1.0.6",
     "oak-ajax-behavior": "fs-webdev/oak-ajax-behavior",
     "oak-i18n-behavior": "fs-webdev/oak-i18n-behavior#1.x",
-    "fs-styles": "fs-webdev/fs-styles"
+    "fs-styles": "fs-webdev/fs-styles#3.x"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#~1.0.6",
     "web-component-tester": "~4.3.1"
   },
   "resolutions": {
-    "polymer": "^1.2.0"
+    "polymer": "^1.2.0",
+    "webcomponentsjs": "^0.7.24"
   }
 }

--- a/fs-artifact-grid-item.css
+++ b/fs-artifact-grid-item.css
@@ -123,14 +123,14 @@
   top: calc(50% - 11px);
 }
 
-fs-card {
-  width: var(--grid-item-card-width);
+.fs-card {
+  width: calc(46vw - 20px);
   max-width: 170px;
-  --fs-card-body: {
-    padding: 0;
-    width: 100%;
-    @apply(--grid-item-card-styles);
-  };
+}
+
+.fs-card__body {
+  padding: 0;
+  width: 100%;
 }
 
 .loading-icon {

--- a/fs-artifact-grid-item.html
+++ b/fs-artifact-grid-item.html
@@ -1,5 +1,4 @@
 <link rel="import" href="../polymer/polymer.html">
-<link rel="import" href="../fs-card/fs-card.html">
 <link rel="import" href="../wc-i18n/wc-i18n.html">
 <link rel="import" href="../oak-i18n-behavior/oak-i18n-behavior.html">
 <link rel="import" href="audio-artifact/audio-artifact.html">
@@ -21,8 +20,8 @@
       method="POST"
       on-response="_handlePostTitleResponse"
       on-error="_handlePostTitleError"></iron-ajax>
-    <fs-card>
-      <div body>
+    <div class="fs-card">
+      <div class="fs-card__body">
         <div class="relative">
           <div id='artifact' class="artifact">
 
@@ -129,7 +128,7 @@
 
         </div>
       </div>
-    </fs-card>
+    </div>
   </template>
 </dom-module>
 <script>


### PR DESCRIPTION
I removed the reference to fs-card since it used the same class name as the CSS in v3 of fs-styles.  This caused a bug where the card would look like two cards stacked on top of each other.