### PR TITLE
Fixing two grid item style bugs

### DIFF
--- a/fs-artifact-grid-item.html
+++ b/fs-artifact-grid-item.html
@@ -238,7 +238,8 @@
       .overlay {
         position: absolute;
         top:0;
-        bottom:36px;
+        bottom: 35px;
+        border-radius: 4px 4px 0 0;
         left:0;
         right:0;
         padding: 10px 10px 15px;


### PR DESCRIPTION
* The overlay was not covering the entire image (off by 1 pixel)
* The overlay's top corners were not rounded