### PR TITLE
Prevent firing metrics and title click in select mode

### DIFF
--- a/fs-artifact-grid-item.html
+++ b/fs-artifact-grid-item.html
@@ -635,7 +635,7 @@
       '_translateContributor(i18n, data.*)'
     ],
     _titleLinkOverride: function(e) {
-      if (this.data.tombstoned) {
+      if (this.selectMode || this.data.tombstoned) {
         e.preventDefault();
         return;
       }
@@ -863,10 +863,12 @@
       }
     },
     _fireGoToItemMetrics: function(e) {
-      if (e.target.classList.contains('not-tagged-icon')) {
-        this.fireMetrics({link_name: 'Artifact: Add Tag Icon'});
+      if (!this.selectMode && !this.data.tombstoned) {
+        if (e.target.classList.contains('not-tagged-icon')) {
+          this.fireMetrics({link_name: 'Artifact: Add Tag Icon'});
+        }
+        this.fireMetrics({link_name: 'Artifact: Click to View'});
       }
-      this.fireMetrics({link_name: 'Artifact: Click to View'});
     },
     _hideTagIcon: function(data, selectMode){
       if (selectMode) {


### PR DESCRIPTION
- If `fs-artifact-grid-item` is in select mode:
  - Don't allow metrics to be fired.
  - Don't navigation to the artifact by clicking on the title.

@chadeddington / @jpodwys / @ta1188 