### PR TITLE
private memory data-test moved

### DIFF
--- a/fs-artifact-grid-item.html
+++ b/fs-artifact-grid-item.html
@@ -457,9 +457,8 @@
               <span 
                 class="private-memory-container"
                 hidden="[[isPublic(data.visibility, privateMemoriesEx)]]" 
-                title="[[i18n('private_memory_tooltip')]]"
-                data-test="gridPrivateMemory">
-                <fs-icon class="private-memory-icon" icon="sign-in-small"></fs-icon>
+                title="[[i18n('private_memory_tooltip')]]">
+                <fs-icon class="private-memory-icon" icon="sign-in-small" data-test="gridPrivateMemory"></fs-icon>
               </span>
             </div>
           </template>


### PR DESCRIPTION
moved data-test for grid private memories to be in the same place as the list data-test (with the fs-icon tag, not the span, as previously uploaded).