### PR TITLE
Fix contributor ellipsis and empty story thumbnail

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-artifact-grid-item",
-  "version": "4.3.8",
+  "version": "4.3.9",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],

--- a/fs-artifact-grid-item.html
+++ b/fs-artifact-grid-item.html
@@ -106,6 +106,7 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         font-size: .88rem;
+        max-width: 145px;
       }
 
       .contributor .contributor-name {

--- a/story-artifact/story-artifact.html
+++ b/story-artifact/story-artifact.html
@@ -72,9 +72,11 @@
       <h1 class="story-content-title">[[title]]</h1>
       <div class="story-content-body">
         <div class="story-content-body-overlay"></div>
-        <div class="story-content-thumbnail" hidden$="{{!imageUrl}}">
-          <img src$="[[imageUrl]]"/>
-        </div>
+        <template is="dom-if" if="{{imageUrl}}">
+          <div class="story-content-thumbnail">
+            <img src$="[[imageUrl]]"/>
+          </div>
+        </template>
         <span>[[description]]</span>
       </div>
     </div>


### PR DESCRIPTION
* Fix layout of contributor name to resolve https://fhjira.churchofjesuschrist.org/browse/PS-3959
* Fix story thumbnail showing even with no image URL to resolve https://fhjira.churchofjesuschrist.org/browse/PS-4019
  * There was existing code to hide this, but I think the `hidden` attribute conflicted with the explicit `display: block` being set on it. I just switched it to a `dom-if`

Before
![image](https://user-images.githubusercontent.com/9064299/90061476-6aee3f00-dca3-11ea-9f05-40a6e0d06cf7.png)

After
<img width="372" alt="image" src="https://user-images.githubusercontent.com/9064299/90061530-7b9eb500-dca3-11ea-8085-1a97ba4401cb.png">
