### PR TITLE
PS-4106: Hide Add Tag button if any tags exist

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fs-artifact-grid-item",
-  "version": "4.3.13",
+  "version": "4.3.14",
   "authors": [
     "Josh Crowther <jshcrowthe@gmail.com>"
   ],

--- a/fs-artifact-grid-item.html
+++ b/fs-artifact-grid-item.html
@@ -912,13 +912,7 @@
       }
     },
     _hideTagIcon: function(data, selectMode){
-      if (selectMode) {
-        return true;
-      } else {
-        // Soft tag count only matters if it's an IMAGE
-        const tagCount = data.category === 'IMAGE' ? data.photoTagCount - data.softTagCount || 0 : data.photoTagCount;
-        return this._is(tagCount, 0) ? false : true;
-      }
+      return selectMode || data.photoTagCount > 0
     },
 
     /**


### PR DESCRIPTION
### Changes
- Hide the `Add Tag` button if any tags exist, including soft tags.