### PR TITLE
Show correct error messages when batchUploadEx is enabled

### DIFF
--- a/fs-artifact-grid-item-preview.html
+++ b/fs-artifact-grid-item-preview.html
@@ -218,6 +218,9 @@
       loading: {
         type: Boolean,
         value: true
+      },
+      batchUploadEx: {
+        value: function(){ return FS.showEx('batchUploadEx'); }
       }
     },
     listeners: {
@@ -248,7 +251,8 @@
       if (!data || !data.promise || typeof data.promise.then !== 'function') return;
       data.promise.then(function (result){
         if(result.err){
-          this._handleUploadError(result.err);
+          const errorStatus = this.batchUploadEx ? result.err.status : result.err;
+          this._handleUploadError(errorStatus);
           return;
         }
       }.bind(this), this._handleUploadError.bind(this));


### PR DESCRIPTION
batchUploadEx changes the way the error object is formatted. This PR checks whether the experiment is enabled and gets the proper error code from the error object so a more specific error message is displayed.

Fixes PS-4159